### PR TITLE
add labels to Geometries

### DIFF
--- a/proto/viam/common/v1/common.proto
+++ b/proto/viam/common/v1/common.proto
@@ -94,6 +94,8 @@ message Geometry {
     Sphere sphere = 2;
     RectangularPrism box = 3;
   }
+  // label of the geometry
+  string label = 4;
 }
 
 // GeometriesinFrame contains the dimensions of a given geometry, pose of its center point, and the reference frame by which it was
@@ -112,8 +114,6 @@ message PointCloudObject {
   bytes point_cloud = 1;
   // volume of a given geometry
   common.v1.GeometriesInFrame geometries = 2;
-  // label of the object
-  string label = 3;
 }
 
 message GeoPoint {

--- a/proto/viam/common/v1/common.proto
+++ b/proto/viam/common/v1/common.proto
@@ -112,6 +112,8 @@ message PointCloudObject {
   bytes point_cloud = 1;
   // volume of a given geometry
   common.v1.GeometriesInFrame geometries = 2;
+  // label of the object
+  string label = 3;
 }
 
 message GeoPoint {

--- a/proto/viam/common/v1/common.proto
+++ b/proto/viam/common/v1/common.proto
@@ -94,7 +94,7 @@ message Geometry {
     Sphere sphere = 2;
     RectangularPrism box = 3;
   }
-  // label of the geometry
+  // Label of the geometry. If none supplied, will be an empty string.
   string label = 4;
 }
 


### PR DESCRIPTION
In order to find 3D objects using the SDK, I need a label to at least switch/filter on. Given that this just adds one field to a meessage should mean its not a breaking change.