### PR TITLE
Remove no uncommitted changes check

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -29,27 +29,3 @@ jobs:
     - uses: bufbuild/buf-breaking-action@v1
       with:
         against: 'https://github.com/viamrobotics/api.git#branch=main'
-
-  validate-local-files:
-    name: Ensure dist/buf ran locally.
-    timeout-minutes: 5
-    runs-on: [self-hosted, x64]
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64-cache
-      options: --platform linux/amd64
-    steps:
-    - uses: actions/checkout@v3
-    - name: Verify no uncommitted changes"
-      run: |
-        git init
-        git add .
-
-        make dist/buf
-
-        GEN_DIFF=$(git status -s)
-
-        if [ -n "$GEN_DIFF" ]; then
-            echo '"make dist/buf" resulted in changes not in git' 1>&2
-            git status
-            exit 1
-        fi

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -40,6 +40,13 @@ jobs:
           default_author: github_actions
           message: Built new protos from ${{ steps.short_sha.outputs.short_sha }} [skip ci]
 
+      - name: Bump tag
+        uses: anothrNick/github-tag-action@1.52.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+          DEFAULT_BUMP: patch
+
   buf-push:
     if: github.repository_owner == 'viamrobotics'
     runs-on: [self-hosted, x64]

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -1,4 +1,4 @@
-name: Buf Push
+name: Compile Protos and Update Buf
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,14 +16,38 @@ on:
   workflow_dispatch:
 
 jobs:
+  compile-protos:
+    if: github.repository_owner == 'viamrobotics'
+    runs-on: [self-hosted, x64]
+    container:
+      image: ghcr.io/viamrobotics/canon:amd64-cache
+      options: --platform linux/amd64
+    steps:
+      - uses: actions/checkout@v3
+      - uses: bufbuild/buf-setup-action@v1
+      - uses: arduino/setup-protoc@v1
+
+      - name: Compile protos
+        run: make dist/buf
+
+      - name: Add SHORT_SHA env property
+        id: short_sha
+        run: echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
+
+      - name: Commit + Push
+        uses: EndBug/add-and-commit@v9.0.0
+        with:
+          default_author: github_actions
+          message: Built new protos from ${{ steps.short_sha.outputs.short_sha }} [skip ci]
+
   buf-push:
     if: github.repository_owner == 'viamrobotics'
     runs-on: [self-hosted, x64]
     container:
-      image: ghcr.io/viamrobotics/canon:amd64
+      image: ghcr.io/viamrobotics/canon:amd64-cache
     steps:
       - uses: actions/checkout@v3
-      - uses: bufbuild/buf-setup-action@v1.8.0
+      - uses: bufbuild/buf-setup-action@v1
       - uses: bufbuild/buf-push-action@v1
         with:
           input: proto/viam


### PR DESCRIPTION
Remove the check for uncommitted changes, and commit the contents of `make dist/buf` via an action. This should override any locally made changes and not care about version mismatches, since it should always compile the source of truth.