### PR TITLE
Update the github token

### DIFF
--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -24,6 +24,8 @@ jobs:
       options: --platform linux/amd64
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.REPO_READ_TOKEN }}
       - uses: bufbuild/buf-setup-action@v1
       - uses: arduino/setup-protoc@v1
 
@@ -43,7 +45,7 @@ jobs:
       - name: Bump tag
         uses: anothrNick/github-tag-action@1.52.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_READ_TOKEN }}
           WITH_V: true
           DEFAULT_BUMP: patch
 


### PR DESCRIPTION
This is a follow up to https://github.com/viamrobotics/api/pull/101, which should fix this https://github.com/viamrobotics/api/actions/runs/3438079708

The issue is that the main branch is protected (as it should be). Can an admin @edaniels @Otterverse etc. update the permissions on this so that the `viambot` user can push directly to main? 

This PR updates the GitHub tokens to use the `viambot` token, similar to how I do it for the [python-sdk](https://github.com/viamrobotics/viam-python-sdk/blob/main/.github/workflows/release.yml#L34), which similarly needs to push directly to main