### PR TITLE
Workflows to generate and commit protos

### DIFF
--- a/.github/workflows/check_merge_reqs.yml
+++ b/.github/workflows/check_merge_reqs.yml
@@ -1,0 +1,27 @@
+name: Check Requirements for Merge
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - labeled
+      - unlabeled
+
+jobs:
+  check_requirements:
+    name: Check Merge Requirements
+    runs-on: [self-hosted, x64]
+    if: github.repository_owner == 'viamrobotics'
+    steps:
+      - name: Check Labels
+        if: >
+          contains(github.event.pull_request.labels.*.name, 'protos-compiled')
+        run: echo "label-checks-pass=true" >> $GITHUB_ENV
+
+      - name: Final Checks
+        if: >
+          env.label-checks-pass == false
+        uses: actions/github-script@v6
+        with:
+          script: core.setFailed('Merge requirements not met.\n\tLabel checks - ${{ env.label-checks-pass }}')

--- a/.github/workflows/compile_protos.yml
+++ b/.github/workflows/compile_protos.yml
@@ -5,38 +5,111 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request_review:
-    branches: [ 'main' ]
-    types: [submitted]
+  workflow_run:
+    workflows: ["On PR Approved"]
+    types:
+      - completed
 
 jobs:
   compile-protos:
-    if: github.event.review.state == 'approved' && github.repository_owner == 'viamrobotics'
+    if: >
+      github.event.workflow_run.event == 'pull_request_review' &&
+      github.event.workflow_run.conclusion == 'success'
     runs-on: [self-hosted, x64]
     container:
       image: ghcr.io/viamrobotics/canon:amd64-cache
       options: --platform linux/amd64
+    env:
+      CI_COMMIT_MESSAGE_PREFIX: Built new protos from
+      CI_COMMIT_AUTHOR: github-actions
+      LABEL_NAME: protos-compiled
     steps:
+      # Download PR info from approval workflow and checkout branch
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          run_id: ${{github.event.workflow_run.id }}
+      - name: Get PR Repo
+        id: get-pr-repo
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            var fs = require('fs');
+            var repo = String(fs.readFileSync('./pr/repo')).trim();
+            return repo
+      - name: Get PR Ref
+        id: get-pr-ref
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            var fs = require('fs');
+            var ref = String(fs.readFileSync('./pr/ref')).trim();
+            return ref
+      - name: Get PR Number
+        id: get-pr-number
+        uses: actions/github-script@v6
+        with:
+          script: |
+            var fs = require('fs');
+            var number = Number(String(fs.readFileSync('./pr/number')).trim());
+            return number
       - uses: actions/checkout@v3
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ steps.get-pr-repo.outputs.result }}
+          ref: ${{ steps.get-pr-ref.outputs.result }}
           token: ${{ secrets.REPO_READ_TOKEN }}
+
+      # Set environment variables based on the last commit
+      - name: Set environment variable "commit-message"
+        run: echo "commit-message=$(git log -1 --pretty=format:'%s')" >> $GITHUB_ENV
+      - name: Set environment variable "commit-author"
+        run: echo "commit-author=$(git log -1 --pretty=format:'%an')" >> $GITHUB_ENV
+
+      # If the last commit is an auto-generated commit from this workflow, we can exit early
+      - name: Set environment variable "is-auto-commit"
+        if: startsWith(env.commit-message, env.CI_COMMIT_MESSAGE_PREFIX) && env.commit-author == env.CI_COMMIT_AUTHOR
+        run: echo "is-auto-commit=true" >> $GITHUB_ENV
+
+      # Remove label if exists, since we're about to compile again
+      - name: Remove label
+        if: env.is-auto-commit == false
+        uses: andymckay/labeler@1.0.4
+        with:
+          repo-token: ${{ secrets.REPO_READ_TOKEN }}
+          remove-labels: ${{ env.LABEL_NAME }}
+          issue-number: ${{ steps.get-pr-number.outputs.result }}
+
+      # Build and push
       - uses: bufbuild/buf-setup-action@v1
+        if: env.is-auto-commit == false
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: arduino/setup-protoc@v1
+        if: env.is-auto-commit == false
 
       - name: Compile protos
+        if: env.is-auto-commit == false
         run: make dist/buf
 
       - name: Add SHORT_SHA env property
+        if: env.is-auto-commit == false
         id: short_sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Commit + Push
+        if: env.is-auto-commit == false
         uses: EndBug/add-and-commit@v9.0.0
         with:
           default_author: github_actions
-          message: Built new protos from ${{ steps.short_sha.outputs.short_sha }} [skip ci]
+          message: ${{ env.CI_COMMIT_MESSAGE_PREFIX }} ${{ steps.short_sha.outputs.short_sha }} [skip ci]
           push: true
+
+      - name: Add label
+        if: env.is-auto-commit == false
+        uses: andymckay/labeler@1.0.4
+        with:
+          repo-token: ${{ secrets.REPO_READ_TOKEN }}
+          add-labels: ${{ env.LABEL_NAME }}
+          issue-number:  ${{ steps.get-pr-number.outputs.result }}

--- a/.github/workflows/on_pr_approved.yml
+++ b/.github/workflows/on_pr_approved.yml
@@ -1,0 +1,23 @@
+name: On PR Approved
+
+on:
+  pull_request_review:
+    branches: [ 'main' ]
+    types: [submitted]
+
+jobs:
+  export_pr_info:
+    name: Export Pull Request Info
+    runs-on: [self-hosted, x64]
+    if: github.event.review.state == 'approved' && github.repository_owner == 'viamrobotics'
+    steps:
+      - name: Save PR repo and ref
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.pull_request.head.repo.full_name }} > ./pr/repo
+          echo ${{ github.event.pull_request.head.ref }} > ./pr/ref
+          echo ${{ github.event.pull_request.number }} > ./pr/number
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/


### PR DESCRIPTION
GitHub doesn't allow workflows to access secrets on PRs from forks (https://securitylab.github.com/research/github-actions-preventing-pwn-requests/). So previously when compiling protos, the workflow could not commit the code back to the head branch because it did not have the necessary secret to do so. 

The new workflow is thus:

1. On PR approval, run an INSECURE workflow that saves the PR information to be used in the next step. This was borrowed from the above link
2. On successful run of the PR Approval workflow, a SECURE workflow kicks off that can compile protos and commit them back in. However, because this workflow is no longer associated with the PR, having it as a required check for merging will never pass. So this workflow then labels the PR with a `protos-compiled` label
3. A third workflow that is associated with the original PR sits waiting for label changes. When a label is added/removed, this workflow will run and can be used as a required check: if the necessary labels exist (currently only `photos-compiled`), then it will pass. Otherwise, it will fail.

The workflows in order are:
1. on_pr_approved.yml
2. compile_protos.yml
3. check_merge_reqs.yml