### PR TITLE
Remove [skip ci]

### DIFF
--- a/.github/workflows/compile_protos.yml
+++ b/.github/workflows/compile_protos.yml
@@ -103,7 +103,7 @@ jobs:
         uses: EndBug/add-and-commit@v9.0.0
         with:
           default_author: github_actions
-          message: ${{ env.CI_COMMIT_MESSAGE_PREFIX }} ${{ steps.short_sha.outputs.short_sha }} [skip ci]
+          message: ${{ env.CI_COMMIT_MESSAGE_PREFIX }} ${{ steps.short_sha.outputs.short_sha }}
           push: true
 
       - name: Add label

--- a/app/datasync/v1/data_sync.pb.go
+++ b/app/datasync/v1/data_sync.pb.go
@@ -138,6 +138,7 @@ type SensorData struct {
 
 	Metadata *SensorMetadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	// Types that are assignable to Data:
+	//
 	//	*SensorData_Struct
 	//	*SensorData_Binary
 	Data isSensorData_Data `protobuf_oneof:"data"`
@@ -399,6 +400,7 @@ type UploadRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to UploadPacket:
+	//
 	//	*UploadRequest_Metadata
 	//	*UploadRequest_SensorContents
 	//	*UploadRequest_FileContents

--- a/app/model/v1/model.pb.go
+++ b/app/model/v1/model.pb.go
@@ -257,6 +257,7 @@ type UploadRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to UploadPacket:
+	//
 	//	*UploadRequest_Metadata
 	//	*UploadRequest_FileContents
 	UploadPacket isUploadRequest_UploadPacket `protobuf_oneof:"upload_packet"`

--- a/app/v1/app_grpc.pb.go
+++ b/app/v1/app_grpc.pb.go
@@ -23,7 +23,7 @@ type AppServiceClient interface {
 	ListLocations(ctx context.Context, in *ListLocationsRequest, opts ...grpc.CallOption) (*ListLocationsResponse, error)
 	LocationAuth(ctx context.Context, in *LocationAuthRequest, opts ...grpc.CallOption) (*LocationAuthResponse, error)
 	// Create a new generated Secret in the Location.
-	//  - Succeeds if there are no more than 2 active secrets after creation.
+	//   - Succeeds if there are no more than 2 active secrets after creation.
 	CreateLocationSecret(ctx context.Context, in *CreateLocationSecretRequest, opts ...grpc.CallOption) (*CreateLocationSecretResponse, error)
 	// Delete a Secret from the Location.
 	DeleteLocationSecret(ctx context.Context, in *DeleteLocationSecretRequest, opts ...grpc.CallOption) (*DeleteLocationSecretResponse, error)
@@ -45,7 +45,7 @@ type AppServiceClient interface {
 	// Marks the given part as the main part, and all the others as not
 	MarkPartAsMain(ctx context.Context, in *MarkPartAsMainRequest, opts ...grpc.CallOption) (*MarkPartAsMainResponse, error)
 	// Create a new generated Secret in the Robot Part.
-	//  - Succeeds if there are no more than 2 active secrets after creation.
+	//   - Succeeds if there are no more than 2 active secrets after creation.
 	CreateRobotPartSecret(ctx context.Context, in *CreateRobotPartSecretRequest, opts ...grpc.CallOption) (*CreateRobotPartSecretResponse, error)
 	// Delete a Secret from the RobotPart.
 	DeleteRobotPartSecret(ctx context.Context, in *DeleteRobotPartSecretRequest, opts ...grpc.CallOption) (*DeleteRobotPartSecretResponse, error)
@@ -297,7 +297,7 @@ type AppServiceServer interface {
 	ListLocations(context.Context, *ListLocationsRequest) (*ListLocationsResponse, error)
 	LocationAuth(context.Context, *LocationAuthRequest) (*LocationAuthResponse, error)
 	// Create a new generated Secret in the Location.
-	//  - Succeeds if there are no more than 2 active secrets after creation.
+	//   - Succeeds if there are no more than 2 active secrets after creation.
 	CreateLocationSecret(context.Context, *CreateLocationSecretRequest) (*CreateLocationSecretResponse, error)
 	// Delete a Secret from the Location.
 	DeleteLocationSecret(context.Context, *DeleteLocationSecretRequest) (*DeleteLocationSecretResponse, error)
@@ -319,7 +319,7 @@ type AppServiceServer interface {
 	// Marks the given part as the main part, and all the others as not
 	MarkPartAsMain(context.Context, *MarkPartAsMainRequest) (*MarkPartAsMainResponse, error)
 	// Create a new generated Secret in the Robot Part.
-	//  - Succeeds if there are no more than 2 active secrets after creation.
+	//   - Succeeds if there are no more than 2 active secrets after creation.
 	CreateRobotPartSecret(context.Context, *CreateRobotPartSecretRequest) (*CreateRobotPartSecretResponse, error)
 	// Delete a Secret from the RobotPart.
 	DeleteRobotPartSecret(context.Context, *DeleteRobotPartSecretRequest) (*DeleteRobotPartSecretResponse, error)

--- a/app/v1/robot.pb.go
+++ b/app/v1/robot.pb.go
@@ -1005,6 +1005,7 @@ type Orientation struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Type:
+	//
 	//	*Orientation_NoOrientation_
 	//	*Orientation_VectorRadians
 	//	*Orientation_VectorDegrees

--- a/common/v1/common.pb.go
+++ b/common/v1/common.pb.go
@@ -246,13 +246,13 @@ func (x *DigitalInterruptStatus) GetValue() int64 {
 }
 
 // Pose is a combination of location and orientation.
-//Location is expressed as distance which is represented by x , y, z coordinates. Orientation is expressed as an orientation vector which
-//is represented by o_x, o_y, o_z and theta. The o_x, o_y, o_z coordinates represent the point on the cartesian unit sphere that the end of
-//the arm is pointing to (with the origin as reference). That unit vector forms an axis around which theta rotates. This means that
-//incrementing / decrementing theta will perform an inline rotation of the end effector.
-//Theta is defined as rotation between two planes: the first being defined by the origin, the point (0,0,1), and the rx, ry, rz point, and the
-//second being defined by the origin, the rx, ry, rz point and the local Z axis. Therefore, if theta is kept at zero as the north/south pole
-//is circled, the Roll will correct itself to remain in-line.
+// Location is expressed as distance which is represented by x , y, z coordinates. Orientation is expressed as an orientation vector which
+// is represented by o_x, o_y, o_z and theta. The o_x, o_y, o_z coordinates represent the point on the cartesian unit sphere that the end of
+// the arm is pointing to (with the origin as reference). That unit vector forms an axis around which theta rotates. This means that
+// incrementing / decrementing theta will perform an inline rotation of the end effector.
+// Theta is defined as rotation between two planes: the first being defined by the origin, the point (0,0,1), and the rx, ry, rz point, and the
+// second being defined by the origin, the rx, ry, rz point and the local Z axis. Therefore, if theta is kept at zero as the north/south pole
+// is circled, the Roll will correct itself to remain in-line.
 type Pose struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -656,6 +656,7 @@ type Geometry struct {
 	// Deminsions of a give geometry. This can be a sphere or box
 	//
 	// Types that are assignable to GeometryType:
+	//
 	//	*Geometry_Sphere
 	//	*Geometry_Box
 	GeometryType isGeometry_GeometryType `protobuf_oneof:"geometry_type"`

--- a/component/arm/v1/arm.pb.go
+++ b/component/arm/v1/arm.pb.go
@@ -241,7 +241,7 @@ type GetJointPositionsResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//a list JointPositions
+	// a list JointPositions
 	Positions *JointPositions `protobuf:"bytes,1,opt,name=positions,proto3" json:"positions,omitempty"`
 }
 

--- a/component/audioinput/v1/audioinput.pb.go
+++ b/component/audioinput/v1/audioinput.pb.go
@@ -314,6 +314,7 @@ type ChunksResponse struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Type:
+	//
 	//	*ChunksResponse_Info
 	//	*ChunksResponse_Chunk
 	Type isChunksResponse_Type `protobuf_oneof:"type"`

--- a/gen/js/google/api/expr/v1alpha1/syntax_pb.d.ts
+++ b/gen/js/google/api/expr/v1alpha1/syntax_pb.d.ts
@@ -184,6 +184,11 @@ export namespace Expr {
     setElementsList(value: Array<Expr>): void;
     addElements(value?: Expr, index?: number): Expr;
 
+    clearOptionalIndicesList(): void;
+    getOptionalIndicesList(): Array<number>;
+    setOptionalIndicesList(value: Array<number>): void;
+    addOptionalIndices(value: number, index?: number): number;
+
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): CreateList.AsObject;
     static toObject(includeInstance: boolean, msg: CreateList): CreateList.AsObject;
@@ -197,6 +202,7 @@ export namespace Expr {
   export namespace CreateList {
     export type AsObject = {
       elementsList: Array<Expr.AsObject>,
+      optionalIndicesList: Array<number>,
     }
   }
 

--- a/gen/js/google/api/expr/v1alpha1/syntax_pb.js
+++ b/gen/js/google/api/expr/v1alpha1/syntax_pb.js
@@ -1319,7 +1319,7 @@ proto.google.api.expr.v1alpha1.Expr.Call.prototype.clearArgsList = function() {
  * @private {!Array<number>}
  * @const
  */
-proto.google.api.expr.v1alpha1.Expr.CreateList.repeatedFields_ = [1];
+proto.google.api.expr.v1alpha1.Expr.CreateList.repeatedFields_ = [1,2];
 
 
 
@@ -1353,7 +1353,8 @@ proto.google.api.expr.v1alpha1.Expr.CreateList.prototype.toObject = function(opt
 proto.google.api.expr.v1alpha1.Expr.CreateList.toObject = function(includeInstance, msg) {
   var f, obj = {
     elementsList: jspb.Message.toObjectList(msg.getElementsList(),
-    proto.google.api.expr.v1alpha1.Expr.toObject, includeInstance)
+    proto.google.api.expr.v1alpha1.Expr.toObject, includeInstance),
+    optionalIndicesList: (f = jspb.Message.getRepeatedField(msg, 2)) == null ? undefined : f
   };
 
   if (includeInstance) {
@@ -1395,6 +1396,12 @@ proto.google.api.expr.v1alpha1.Expr.CreateList.deserializeBinaryFromReader = fun
       reader.readMessage(value,proto.google.api.expr.v1alpha1.Expr.deserializeBinaryFromReader);
       msg.addElements(value);
       break;
+    case 2:
+      var values = /** @type {!Array<number>} */ (reader.isDelimited() ? reader.readPackedInt32() : [reader.readInt32()]);
+      for (var i = 0; i < values.length; i++) {
+        msg.addOptionalIndices(values[i]);
+      }
+      break;
     default:
       reader.skipField();
       break;
@@ -1430,6 +1437,13 @@ proto.google.api.expr.v1alpha1.Expr.CreateList.serializeBinaryToWriter = functio
       1,
       f,
       proto.google.api.expr.v1alpha1.Expr.serializeBinaryToWriter
+    );
+  }
+  f = message.getOptionalIndicesList();
+  if (f.length > 0) {
+    writer.writePackedInt32(
+      2,
+      f
     );
   }
 };
@@ -1470,6 +1484,43 @@ proto.google.api.expr.v1alpha1.Expr.CreateList.prototype.addElements = function(
  */
 proto.google.api.expr.v1alpha1.Expr.CreateList.prototype.clearElementsList = function() {
   return this.setElementsList([]);
+};
+
+
+/**
+ * repeated int32 optional_indices = 2;
+ * @return {!Array<number>}
+ */
+proto.google.api.expr.v1alpha1.Expr.CreateList.prototype.getOptionalIndicesList = function() {
+  return /** @type {!Array<number>} */ (jspb.Message.getRepeatedField(this, 2));
+};
+
+
+/**
+ * @param {!Array<number>} value
+ * @return {!proto.google.api.expr.v1alpha1.Expr.CreateList} returns this
+ */
+proto.google.api.expr.v1alpha1.Expr.CreateList.prototype.setOptionalIndicesList = function(value) {
+  return jspb.Message.setField(this, 2, value || []);
+};
+
+
+/**
+ * @param {number} value
+ * @param {number=} opt_index
+ * @return {!proto.google.api.expr.v1alpha1.Expr.CreateList} returns this
+ */
+proto.google.api.expr.v1alpha1.Expr.CreateList.prototype.addOptionalIndices = function(value, opt_index) {
+  return jspb.Message.addToRepeatedField(this, 2, value, opt_index);
+};
+
+
+/**
+ * Clears the list making it empty but non-null.
+ * @return {!proto.google.api.expr.v1alpha1.Expr.CreateList} returns this
+ */
+proto.google.api.expr.v1alpha1.Expr.CreateList.prototype.clearOptionalIndicesList = function() {
+  return this.setOptionalIndicesList([]);
 };
 
 

--- a/service/slam/v1/slam.pb.go
+++ b/service/slam/v1/slam.pb.go
@@ -231,6 +231,7 @@ type GetMapResponse struct {
 	// Image or point cloud of mime_type.
 	//
 	// Types that are assignable to Map:
+	//
 	//	*GetMapResponse_PointCloud
 	//	*GetMapResponse_Image
 	Map isGetMapResponse_Map `protobuf_oneof:"map"`


### PR DESCRIPTION
The `[skip ci]` tag at the end of the commit message was there to prevent this auto-generated commit from running CI (makes sense). 

The issue is that because the workflow adds a new commit to the PR, we need to run the PR test workflow again to pass the required check. Removing this should enable that workflow to run