### PR TITLE
APP-1218: adding new grpc endpoint for health check

### DIFF
--- a/proto/viam/buf.yaml
+++ b/proto/viam/buf.yaml
@@ -13,6 +13,8 @@ lint:
     - DEFAULT
   except:
     - PACKAGE_DIRECTORY_MATCH
+  ignore:
+    - health/v1/health.proto
   ignore_only:
     RPC_RESPONSE_STANDARD_NAME:
       - component/camera/v1/camera.proto

--- a/proto/viam/health/v1/health.proto
+++ b/proto/viam/health/v1/health.proto
@@ -1,0 +1,26 @@
+// copied from https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+// buf:lint:ignore
+syntax = "proto3";
+
+package viam.health.v1;
+
+option go_package = "go.viam.com/api/health/v1";
+
+message HealthCheckRequest {
+  string service = 1;
+}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3; // Used only by the Watch method.
+  }
+  ServingStatus status = 1;
+}
+
+service Health {
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}


### PR DESCRIPTION
This is copied from the grpc: https://github.com/grpc/grpc/blob/master/doc/health-checking.md

I implemented my own server functions so that we can ping the database to make sure that that is running as well as the server itself. For now, we have the option to support different service checks, but I have left this out for now. 