### PR TITLE
Specify shell to make sure macOS `make` respects `PATH`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := bash
+
 PROTO_FILES := $(shell find proto/ -type f -name '*.proto')
 
 export GOBIN := $(shell pwd)/bin/gotools/$(shell uname -s)-$(shell uname -m)

--- a/component/arm/v1/arm.pb.gw.go
+++ b/component/arm/v1/arm.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	v1_0 "go.viam.com/api/common/v1"
+	"go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -439,7 +439,7 @@ var (
 )
 
 func request_ArmService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client ArmServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -472,7 +472,7 @@ func request_ArmService_DoCommand_0(ctx context.Context, marshaler runtime.Marsh
 }
 
 func local_request_ArmService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server ArmServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -505,7 +505,7 @@ func local_request_ArmService_DoCommand_0(ctx context.Context, marshaler runtime
 }
 
 func request_ArmService_GetKinematics_0(ctx context.Context, marshaler runtime.Marshaler, client ArmServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.GetKinematicsRequest
+	var protoReq v1.GetKinematicsRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -531,7 +531,7 @@ func request_ArmService_GetKinematics_0(ctx context.Context, marshaler runtime.M
 }
 
 func local_request_ArmService_GetKinematics_0(ctx context.Context, marshaler runtime.Marshaler, server ArmServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.GetKinematicsRequest
+	var protoReq v1.GetKinematicsRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -557,7 +557,7 @@ func local_request_ArmService_GetKinematics_0(ctx context.Context, marshaler run
 }
 
 func request_ArmService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, client ArmServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.GetGeometriesRequest
+	var protoReq v1.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -583,7 +583,7 @@ func request_ArmService_GetGeometries_0(ctx context.Context, marshaler runtime.M
 }
 
 func local_request_ArmService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, server ArmServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.GetGeometriesRequest
+	var protoReq v1.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/component/camera/v1/camera.pb.gw.go
+++ b/component/camera/v1/camera.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	"go.viam.com/api/common/v1"
+	v1_0 "go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -299,7 +299,7 @@ var (
 )
 
 func request_CameraService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client CameraServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -332,7 +332,7 @@ func request_CameraService_DoCommand_0(ctx context.Context, marshaler runtime.Ma
 }
 
 func local_request_CameraService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server CameraServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -365,7 +365,7 @@ func local_request_CameraService_DoCommand_0(ctx context.Context, marshaler runt
 }
 
 func request_CameraService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, client CameraServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -391,7 +391,7 @@ func request_CameraService_GetGeometries_0(ctx context.Context, marshaler runtim
 }
 
 func local_request_CameraService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, server CameraServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/component/encoder/v1/encoder.pb.gw.go
+++ b/component/encoder/v1/encoder.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	"go.viam.com/api/common/v1"
+	v1_0 "go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -247,7 +247,7 @@ var (
 )
 
 func request_EncoderService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client EncoderServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -280,7 +280,7 @@ func request_EncoderService_DoCommand_0(ctx context.Context, marshaler runtime.M
 }
 
 func local_request_EncoderService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server EncoderServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -313,7 +313,7 @@ func local_request_EncoderService_DoCommand_0(ctx context.Context, marshaler run
 }
 
 func request_EncoderService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, client EncoderServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -339,7 +339,7 @@ func request_EncoderService_GetGeometries_0(ctx context.Context, marshaler runti
 }
 
 func local_request_EncoderService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, server EncoderServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/component/motor/v1/motor.pb.gw.go
+++ b/component/motor/v1/motor.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	"go.viam.com/api/common/v1"
+	v1_0 "go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -649,7 +649,7 @@ var (
 )
 
 func request_MotorService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client MotorServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -682,7 +682,7 @@ func request_MotorService_DoCommand_0(ctx context.Context, marshaler runtime.Mar
 }
 
 func local_request_MotorService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server MotorServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -715,7 +715,7 @@ func local_request_MotorService_DoCommand_0(ctx context.Context, marshaler runti
 }
 
 func request_MotorService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, client MotorServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -741,7 +741,7 @@ func request_MotorService_GetGeometries_0(ctx context.Context, marshaler runtime
 }
 
 func local_request_MotorService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, server MotorServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/component/posetracker/v1/pose_tracker.pb.gw.go
+++ b/component/posetracker/v1/pose_tracker.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	"go.viam.com/api/common/v1"
+	v1_0 "go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -107,7 +107,7 @@ var (
 )
 
 func request_PoseTrackerService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client PoseTrackerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -140,7 +140,7 @@ func request_PoseTrackerService_DoCommand_0(ctx context.Context, marshaler runti
 }
 
 func local_request_PoseTrackerService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server PoseTrackerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -173,7 +173,7 @@ func local_request_PoseTrackerService_DoCommand_0(ctx context.Context, marshaler
 }
 
 func request_PoseTrackerService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, client PoseTrackerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -199,7 +199,7 @@ func request_PoseTrackerService_GetGeometries_0(ctx context.Context, marshaler r
 }
 
 func local_request_PoseTrackerService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, server PoseTrackerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/service/datamanager/v1/data_manager.pb.gw.go
+++ b/service/datamanager/v1/data_manager.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	"go.viam.com/api/common/v1"
+	v1_0 "go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -107,7 +107,7 @@ var (
 )
 
 func request_DataManagerService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client DataManagerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -140,7 +140,7 @@ func request_DataManagerService_DoCommand_0(ctx context.Context, marshaler runti
 }
 
 func local_request_DataManagerService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server DataManagerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/service/motion/v1/motion.pb.gw.go
+++ b/service/motion/v1/motion.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	v1_0 "go.viam.com/api/common/v1"
+	"go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -387,7 +387,7 @@ var (
 )
 
 func request_MotionService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client MotionServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -420,7 +420,7 @@ func request_MotionService_DoCommand_0(ctx context.Context, marshaler runtime.Ma
 }
 
 func local_request_MotionService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server MotionServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/service/navigation/v1/navigation.pb.gw.go
+++ b/service/navigation/v1/navigation.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	v1_0 "go.viam.com/api/common/v1"
+	"go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -477,7 +477,7 @@ var (
 )
 
 func request_NavigationService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client NavigationServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -510,7 +510,7 @@ func request_NavigationService_DoCommand_0(ctx context.Context, marshaler runtim
 }
 
 func local_request_NavigationService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server NavigationServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/service/slam/v1/slam.pb.gw.go
+++ b/service/slam/v1/slam.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	v1_0 "go.viam.com/api/common/v1"
+	"go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -157,7 +157,7 @@ var (
 )
 
 func request_SLAMService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client SLAMServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -190,7 +190,7 @@ func request_SLAMService_DoCommand_0(ctx context.Context, marshaler runtime.Mars
 }
 
 func local_request_SLAMService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server SLAMServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (


### PR DESCRIPTION
This PR adds `SHELL := bash` to the Makefile because without it macOS `make` does not respect `export PATH`. Anecdotally, this is not [the first time I've seen this](https://github.com/Opentrons/opentrons/pull/4809). For fun, also see [this Stack Overflow post from 2014](https://stackoverflow.com/questions/21708839/problems-setting-path-in-makefile/21709821#21709821)!

This is probably a good thing to do by default in our Makefiles anyway. For example, it's part of [this style guide's default prologue](https://clarkgrubb.com/makefile-style-guide#prologue). From that styleguide, setting `.SHELLOPTIONS` seems like an potentially good move to consider, too