### PR TITLE
Add billing_tier to GetOrgBillingInformationResponse

### DIFF
--- a/proto/viam/app/v1/billing.proto
+++ b/proto/viam/app/v1/billing.proto
@@ -154,6 +154,8 @@ message GetOrgBillingInformationResponse {
 
   // defined if type is PAYMENT_METHOD_TYPE_CARD
   optional PaymentMethodCard method = 3;
+  // Only return billing_tier for billing dashboard admin users
+  optional string billing_tier = 4;
 }
 
 message GetInvoicesSummaryRequest {


### PR DESCRIPTION
adds an optional field `billing_tier` to `GetOrgBillingInformationResponse`, which will only be returned for billing dashboard admins. 