### PR TITLE
APP-2311 Endpoint to get user by ID

### DIFF
--- a/proto/viam/app/v1/app.proto
+++ b/proto/viam/app/v1/app.proto
@@ -14,6 +14,9 @@ service AppService {
   // Get the id of the user with the email
   rpc GetUserIDByEmail(GetUserIDByEmailRequest) returns (GetUserIDByEmailResponse);
 
+  // Get user by ID
+  rpc GetUserByID(GetUserByIDRequest) returns (GetUserByIDResponse);
+
   // Organizations
 
   // Create a new organization
@@ -927,6 +930,21 @@ message GetUserIDByEmailRequest {
 
 message GetUserIDByEmailResponse {
   string user_id = 1;
+}
+
+message User {
+  string id = 1;
+  repeated string emails = 2;
+  google.protobuf.Timestamp date_added = 3;
+  google.protobuf.Timestamp last_login = 4;
+}
+
+message GetUserByIDRequest {
+  string id = 1;
+}
+
+message GetUserByIDResponse {
+  User user = 1;
 }
 
 message ListOrganizationsByUserRequest {


### PR DESCRIPTION
This is needed to support the org settings page and robot/location permissions.
Now that users can have robot/location authorizations, we do not want universally list all organization members. Instead, users should only be able to see other users that share authorizations on the resources they have access to.

To do so, we will fetch other users by the authorizations fetched from `listAuthorizations`, instead of relying on getting all org members put on `window.theData`