### PR TITLE
APP-2448 Add comment about sorting order

### DIFF
--- a/app/v1/app.pb.go
+++ b/app/v1/app.pb.go
@@ -7033,6 +7033,7 @@ type Module struct {
 	// The visibility of the module
 	Visibility Visibility `protobuf:"varint,3,opt,name=visibility,proto3,enum=viam.app.v1.Visibility" json:"visibility,omitempty"`
 	// The versions of the module that are available
+	// When this is returned from the backend, the versions are sorted in ascending order by the semver version
 	Versions []*VersionHistory `protobuf:"bytes,4,rep,name=versions,proto3" json:"versions,omitempty"`
 	// The url to reference for documentation, code, etc.
 	Url string `protobuf:"bytes,5,opt,name=url,proto3" json:"url,omitempty"`

--- a/component/gantry/v1/gantry.pb.gw.go
+++ b/component/gantry/v1/gantry.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	v1_0 "go.viam.com/api/common/v1"
+	"go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -439,7 +439,7 @@ var (
 )
 
 func request_GantryService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client GantryServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -472,7 +472,7 @@ func request_GantryService_DoCommand_0(ctx context.Context, marshaler runtime.Ma
 }
 
 func local_request_GantryService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server GantryServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -509,7 +509,7 @@ var (
 )
 
 func request_GantryService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, client GantryServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.GetGeometriesRequest
+	var protoReq v1.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -542,7 +542,7 @@ func request_GantryService_GetGeometries_0(ctx context.Context, marshaler runtim
 }
 
 func local_request_GantryService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, server GantryServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.GetGeometriesRequest
+	var protoReq v1.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/component/motor/v1/motor.pb.gw.go
+++ b/component/motor/v1/motor.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	"go.viam.com/api/common/v1"
+	v1_0 "go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -649,7 +649,7 @@ var (
 )
 
 func request_MotorService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client MotorServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -682,7 +682,7 @@ func request_MotorService_DoCommand_0(ctx context.Context, marshaler runtime.Mar
 }
 
 func local_request_MotorService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server MotorServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -719,7 +719,7 @@ var (
 )
 
 func request_MotorService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, client MotorServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -752,7 +752,7 @@ func request_MotorService_GetGeometries_0(ctx context.Context, marshaler runtime
 }
 
 func local_request_MotorService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, server MotorServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/component/movementsensor/v1/movementsensor.pb.gw.go
+++ b/component/movementsensor/v1/movementsensor.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	"go.viam.com/api/common/v1"
+	v1_0 "go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -597,7 +597,7 @@ var (
 )
 
 func request_MovementSensorService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client MovementSensorServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -630,7 +630,7 @@ func request_MovementSensorService_DoCommand_0(ctx context.Context, marshaler ru
 }
 
 func local_request_MovementSensorService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server MovementSensorServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -667,7 +667,7 @@ var (
 )
 
 func request_MovementSensorService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, client MovementSensorServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -700,7 +700,7 @@ func request_MovementSensorService_GetGeometries_0(ctx context.Context, marshale
 }
 
 func local_request_MovementSensorService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, server MovementSensorServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/component/posetracker/v1/pose_tracker.pb.gw.go
+++ b/component/posetracker/v1/pose_tracker.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	v1_0 "go.viam.com/api/common/v1"
+	"go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -107,7 +107,7 @@ var (
 )
 
 func request_PoseTrackerService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client PoseTrackerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -140,7 +140,7 @@ func request_PoseTrackerService_DoCommand_0(ctx context.Context, marshaler runti
 }
 
 func local_request_PoseTrackerService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server PoseTrackerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -177,7 +177,7 @@ var (
 )
 
 func request_PoseTrackerService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, client PoseTrackerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.GetGeometriesRequest
+	var protoReq v1.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -210,7 +210,7 @@ func request_PoseTrackerService_GetGeometries_0(ctx context.Context, marshaler r
 }
 
 func local_request_PoseTrackerService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, server PoseTrackerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.GetGeometriesRequest
+	var protoReq v1.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/proto/viam/app/v1/app.proto
+++ b/proto/viam/app/v1/app.proto
@@ -893,6 +893,7 @@ message Module {
   // The visibility of the module
   Visibility visibility = 3;
   // The versions of the module that are available
+  // When this is returned from the backend, it is sorted in ascending order by the semver version
   repeated VersionHistory versions = 4;
   // The url to reference for documentation, code, etc.
   string url = 5;

--- a/proto/viam/app/v1/app.proto
+++ b/proto/viam/app/v1/app.proto
@@ -893,7 +893,7 @@ message Module {
   // The visibility of the module
   Visibility visibility = 3;
   // The versions of the module that are available
-  // When this is returned from the backend, it is sorted in ascending order by the semver version
+  // When this is returned from the backend, the versions are sorted in ascending order by the semver version
   repeated VersionHistory versions = 4;
   // The url to reference for documentation, code, etc.
   string url = 5;


### PR DESCRIPTION
The wording for this was specifically chosen so that if we ever end up accepting a `Module` in a message, that the user doesn't think that they have to sort the versions.

I could also just add this to GetModule{}, but it felt strange to attach this comment to an unrelated field.