### PR TITLE
[DATA-1909] Add any type to sensor and tabular data messages

### DIFF
--- a/proto/viam/app/data/v1/data.proto
+++ b/proto/viam/app/data/v1/data.proto
@@ -168,6 +168,7 @@ message TabularData {
   uint32 metadata_index = 2;
   google.protobuf.Timestamp time_requested = 3;
   google.protobuf.Timestamp time_received = 4;
+  google.protobuf.Any any = 5;
 }
 
 message BinaryData {

--- a/proto/viam/app/datasync/v1/data_sync.proto
+++ b/proto/viam/app/datasync/v1/data_sync.proto
@@ -68,6 +68,7 @@ message SensorData {
   oneof data {
     google.protobuf.Struct struct = 2;
     bytes binary = 3;
+    google.protobuf.Any any = 4;
   }
 }
 


### PR DESCRIPTION
This change is part of queryable tabular data. I updated the `TabularData` and `SensorData` message to include this new any field as discussed [here](https://docs.google.com/document/d/1cdNFkIwqNAMaev4jvyr0r6tH-4qOS51vgJsWGIMdmBo/edit). The current struct was not removed from either to keep migration/coordinating this work easier. 