### PR TITLE
Added proto messages for adding a role to and removing role from api key

### DIFF
--- a/proto/viam/app/v1/app.proto
+++ b/proto/viam/app/v1/app.proto
@@ -773,6 +773,7 @@ message Authorization {
   string identity_id = 5;
   string organization_id = 6;
   string identity_type = 7;
+  string api_key = 8;
 }
 
 message AddRoleRequest {


### PR DESCRIPTION
I will be adding the `api_key` field to the Authorization type definition to enable us more easily support `AddRole` and `RemoveRole` for api keys. Adding the API Key field to the authorization field enables us perform necessary lookups for during authorization.