### PR TITLE
APP-2593: Support API key pairs robot config CredentialType

### DIFF
--- a/proto/viam/app/v1/robot.proto
+++ b/proto/viam/app/v1/robot.proto
@@ -270,9 +270,12 @@ message AgentInfo {
 enum CredentialsType {
   CREDENTIALS_TYPE_UNSPECIFIED = 0;
   CREDENTIALS_TYPE_INTERNAL = 1;
+  // deprecated: legacy single string API key implementation
   CREDENTIALS_TYPE_API_KEY = 2;
   CREDENTIALS_TYPE_ROBOT_SECRET = 3;
   CREDENTIALS_TYPE_ROBOT_LOCATION_SECRET = 4;
+  // replaces CREDENTIALS_TYPE_API_KEY; key string by key ID string mapping
+  CREDENTIALS_TYPE_API_KEY_PAIR = 5;
 }
 
 message ConfigRequest {


### PR DESCRIPTION
Required for [APP-2593](https://viam.atlassian.net/browse/APP-2593) and [APP-2595](https://viam.atlassian.net/browse/APP-2595).

This is so that in the `rdk` codebase, we can add to this `switch` statement [here](https://github.com/viamrobotics/rdk/blob/55cab43ce0a2f5bf08caf929761afc5e750a6650/robot/web/web.go#L1033-L1059) to handle the new CredentialsType. We appear to handle translation between `rdk`'s notion of a credential type and the actual API key type [here](https://github.com/viamrobotics/rdk/blob/961321ac0b3d2e3d3b3d9928e468d89e530e710b/config/proto_conversions.go#L720-L733). [Asked](https://github.com/viamrobotics/goutils/pull/203#issuecomment-1745659205) to squeeze a new constant into the `goutils` update PR so we can handle this new API key type the same as the old one.

[APP-2593]: https://viam.atlassian.net/browse/APP-2593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2595]: https://viam.atlassian.net/browse/APP-2595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ