### PR TITLE
APP-2888: add AppValidationStatus field for api

### DIFF
--- a/proto/viam/app/v1/robot.proto
+++ b/proto/viam/app/v1/robot.proto
@@ -47,6 +47,10 @@ message LocationSecret {
   string secret = 2;
 }
 
+message AppValidationStatus {
+  string error = 1;
+}
+
 message CloudConfig {
   // Robot part id.
   string id = 1;
@@ -334,6 +338,8 @@ message ModuleConfig {
   string module_id = 5;
   // additional environment variables passed to the module process
   map<string, string> env = 6;
+  // info about the validity of the module 
+  AppValidationStatus status = 7;
 }
 
 // PackageConfig is the configration for deployed Packages.
@@ -346,4 +352,6 @@ message PackageConfig {
   string version = 3;
   // type of the package
   string type = 4;
+  // info about the validity of the package 
+  AppValidationStatus status = 7;
 }


### PR DESCRIPTION
If there are cloud validations that fail on config retrieval, we want to return that the user but not actually return an error. This accomplishes that. 

Goes hand-in-hand with: 
https://github.com/viamrobotics/app/pull/2672 
https://github.com/viamrobotics/rdk/pull/3078

- this needs to be merged in first 
- and then RDK + then APP