### PR TITLE
RSDK-5471 - Change RDK implementation of MoveOnMap to MoveOnMapNew

### DIFF
--- a/proto/viam/service/motion/v1/motion.proto
+++ b/proto/viam/service/motion/v1/motion.proto
@@ -18,6 +18,9 @@ service MotionService {
     };
   }
 
+  // Generate a plan and move a component to a specific pose
+  // with respect to the SLAM map's origin.
+  // May replan to avoid obstacles
   rpc MoveOnMap(MoveOnMapRequest) returns (MoveOnMapResponse) {
     option (google.api.http) = {
       post: "/viam/api/v1/service/motion/{name}/move_on_map"
@@ -27,6 +30,7 @@ service MotionService {
   // Generate a plan and move a component to a specific pose
   // with respect to the SLAM map's origin.
   // May replan to avoid obstacles
+  [deprecated = true];
   rpc MoveOnMapNew(MoveOnMapNewRequest) returns (MoveOnMapNewResponse) {
     option (google.api.http) = {
       get: "/viam/api/v1/service/motion/{name}/move_on_map_new"
@@ -108,6 +112,7 @@ message MoveResponse {
   bool success = 1;
 }
 
+[deprecated = true];
 message MoveOnMapNewRequest {
   // Name of the motion service
   string name = 1;
@@ -123,6 +128,7 @@ message MoveOnMapNewRequest {
   google.protobuf.Struct extra = 99;
 }
 
+[deprecated = true];
 message MoveOnMapNewResponse {
   // The unique ID which identifies the execution.
   // Multiple plans will share the same execution_id if they were
@@ -139,12 +145,17 @@ message MoveOnMapRequest {
   common.v1.ResourceName component_name = 3;
   // Name of the slam service from which the SLAM map is requested
   common.v1.ResourceName slam_service_name = 4;
+  // Optional set of motion configuration options
+  optional MotionConfiguration motion_configuration = 5;
   // Additional arguments to the method
   google.protobuf.Struct extra = 99;
 }
 
 message MoveOnMapResponse {
-  bool success = 1;
+  // The unique ID which identifies the execution.
+  // Multiple plans will share the same execution_id if they were
+  // generated due to replanning.
+  string execution_id = 1;
 }
 
 // Pairs a vision service with a camera, informing the service about which camera it may use

--- a/proto/viam/service/motion/v1/motion.proto
+++ b/proto/viam/service/motion/v1/motion.proto
@@ -30,8 +30,8 @@ service MotionService {
   // Generate a plan and move a component to a specific pose
   // with respect to the SLAM map's origin.
   // May replan to avoid obstacles
-  [deprecated = true];
   rpc MoveOnMapNew(MoveOnMapNewRequest) returns (MoveOnMapNewResponse) {
+    option deprecated = true;
     option (google.api.http) = {
       get: "/viam/api/v1/service/motion/{name}/move_on_map_new"
     };
@@ -112,8 +112,8 @@ message MoveResponse {
   bool success = 1;
 }
 
-[deprecated = true];
 message MoveOnMapNewRequest {
+  option deprecated = true;
   // Name of the motion service
   string name = 1;
   // Specify a destination to, which can be any pose with respect to the SLAM map's origin
@@ -128,8 +128,8 @@ message MoveOnMapNewRequest {
   google.protobuf.Struct extra = 99;
 }
 
-[deprecated = true];
 message MoveOnMapNewResponse {
+  option deprecated = true;
   // The unique ID which identifies the execution.
   // Multiple plans will share the same execution_id if they were
   // generated due to replanning.


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-5471)

### Follow ups:

1. Docs change: https://github.com/viamrobotics/docs/pull/2426 
2. RDK change: https://github.com/viamrobotics/rdk/pull/3475
3. Typescript SDK change: https://github.com/viamrobotics/viam-typescript-sdk/pull/234
4. Python SDK change: https://github.com/viamrobotics/viam-python-sdk/pull/530


### Changes:

1. Change motion.MoveOnMap, its inputs & outputs to match that of motion.MoveOnMapNew
2. Deprecate motion.MoveOnMapNew. Will be removed as a follow-up.