### PR TITLE
move license_finder job off qemu runner

### DIFF
--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -8,10 +8,9 @@ on:
 jobs:
   license_finder:
     name: Audit 3rd-Party Licenses
-    runs-on: [x64, qemu-host]
+    runs-on: ubuntu-latest
     container:
-      image: ghcr.io/viamrobotics/canon:amd64-cache
-      options: --platform linux/amd64
+      image: ghcr.io/viamrobotics/canon:amd64
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -9,8 +9,7 @@ jobs:
   license_finder:
     name: Audit 3rd-Party Licenses
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64
+    container: ghcr.io/viamrobotics/canon:amd64
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## What changed
- move license_finder job to hosted runner
## Why
- shorten queues