### PR TITLE
move pr-labeler to pull_request_target

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,13 +1,13 @@
 name: PR Test Label Manager
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ main ]
     types: [ opened, synchronize, reopened ]
 
 jobs:
   pr_test_label_manager:
-    # note: this doesn't check 'safe to test' label because it doesn't check out code
+    # note: this doesn't gate on 'safe to test' label because it doesn't check out code
     name: PR Test Label Manager
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tag_and_release_protos.yml
+++ b/.github/workflows/tag_and_release_protos.yml
@@ -18,10 +18,8 @@ on:
 jobs:
   bump-tag:
     if: github.repository_owner == 'viamrobotics'
-    runs-on: [self-hosted, x64]
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64-cache
-      options: --platform linux/amd64
+    runs-on: ubuntu-latest
+    container: ghcr.io/viamrobotics/canon:amd64
     outputs:
       new_tag: ${{ steps.bump.outputs.new_tag }}
     steps:
@@ -37,9 +35,8 @@ jobs:
   buf-push:
     needs: bump-tag
     if: github.repository_owner == 'viamrobotics'
-    runs-on: [self-hosted, x64]
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64-cache
+    runs-on: ubuntu-latest
+    container: ghcr.io/viamrobotics/canon:amd64
     steps:
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1
@@ -52,9 +49,8 @@ jobs:
   dispatch:
     needs: buf-push
     if: github.repository_owner == 'viamrobotics'
-    runs-on: [self-hosted, x64]
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64
+    runs-on: ubuntu-latest
+    container: ghcr.io/viamrobotics/canon:amd64
     strategy:
       matrix:
         repo:


### PR DESCRIPTION
I think that in `on: pull_request`, it can't access org membership from a fork.

check_merge_reqs remains `on: pull_request` -- it only edits the PR itself, :crossed_fingers: that's okay.