### PR TITLE
check out fork in compile_protos

### DIFF
--- a/.github/workflows/compile_protos.yml
+++ b/.github/workflows/compile_protos.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           # note: check out fork because we will need it when we push below
-          repository: ${{ github.event.pull_request.head.repo.forks_url }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - uses: actions/setup-node@v4
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/compile_protos.yml
+++ b/.github/workflows/compile_protos.yml
@@ -42,6 +42,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # note: check out fork because we will need it when we push below
+          repository: ${{ github.event.pull_request.head.repo.forks_url }}
       - uses: actions/setup-node@v4
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
The PR branch doesn't exist on the upstream repo; use `head.repo.full_name` instead so the commit + push step of compile_protos works when the PR is coming from a fork.