### PR TITLE
Add namespace filter to ListRegistryItems

### DIFF
--- a/proto/viam/app/v1/app.proto
+++ b/proto/viam/app/v1/app.proto
@@ -972,6 +972,8 @@ message ListRegistryItemsRequest {
   repeated RegistryItemStatus statuses = 5;
   optional string search_term = 6;
   optional string page_token = 7;
+  // One or more public namespaces to return results for.
+  repeated string public_namespaces = 8;
 }
 
 message ListRegistryItemsResponse {


### PR DESCRIPTION
Allows filtering registry items to a specific namespace. I chose a list because we may use this filter for more purposes in the future such as a filter for "Viam Supported" which could use multiple namespaces.

Change was sent over email for approval.