### PR TITLE
APP-4949: TransferRegistryItem API

### DIFF
--- a/proto/viam/app/v1/app.proto
+++ b/proto/viam/app/v1/app.proto
@@ -195,6 +195,8 @@ service AppService {
 
   rpc DeleteRegistryItem(DeleteRegistryItemRequest) returns (DeleteRegistryItemResponse);
 
+  rpc TransferRegistryItem (TransferRegistryItemRequest) returns (TransferRegistryItemResponse);
+
   rpc CreateModule(CreateModuleRequest) returns (CreateModuleResponse);
 
   rpc UpdateModule(UpdateModuleRequest) returns (UpdateModuleResponse);
@@ -1006,6 +1008,13 @@ message DeleteRegistryItemRequest {
 }
 
 message DeleteRegistryItemResponse {}
+
+message TransferRegistryItemRequest {
+  string item_id = 1;
+  string new_public_namespace = 2;
+}
+
+message TransferRegistryItemResponse {}
 
 // Modules
 message CreateModuleRequest {


### PR DESCRIPTION
Adds protos for a TransferRegistryItem API allowing the transfer of ML models and modules from one organization to another.