### PR TITLE
update docs with new behavior

### DIFF
--- a/proto/viam/robot/v1/robot.proto
+++ b/proto/viam/robot/v1/robot.proto
@@ -410,7 +410,8 @@ message ResourceStatus {
   // revision of the last config that successfully updated this resource.
   string revision = 4;
 
-  // error details for a resource that is in an unhealthy state.
+  // error details for a resource. This is guaranteed to be null if the
+  // resource is ready and non-null if the resource unhealthy.
   string error = 5;
 }
 


### PR DESCRIPTION
Document new behavior: error details might be presents for states other than "unhealthy" but never for the "ready" state: https://github.com/viamrobotics/rdk/pull/4257#discussion_r1723566398.