### PR TITLE
bump min golang version

### DIFF
--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -9,7 +9,7 @@ jobs:
   license_finder:
     name: Audit 3rd-Party Licenses
     runs-on: ubuntu-latest
-    container: ghcr.io/viamrobotics/canon:amd64
+    container: ghcr.io/viamrobotics/rdk-devenv:amd64
     timeout-minutes: 30
 
     steps:

--- a/component/base/v1/base.pb.gw.go
+++ b/component/base/v1/base.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	v1_0 "go.viam.com/api/common/v1"
+	"go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -439,7 +439,7 @@ var (
 )
 
 func request_BaseService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client BaseServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -472,7 +472,7 @@ func request_BaseService_DoCommand_0(ctx context.Context, marshaler runtime.Mars
 }
 
 func local_request_BaseService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server BaseServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -509,7 +509,7 @@ var (
 )
 
 func request_BaseService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, client BaseServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.GetGeometriesRequest
+	var protoReq v1.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -542,7 +542,7 @@ func request_BaseService_GetGeometries_0(ctx context.Context, marshaler runtime.
 }
 
 func local_request_BaseService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, server BaseServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.GetGeometriesRequest
+	var protoReq v1.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/component/board/v1/board.pb.gw.go
+++ b/component/board/v1/board.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	"go.viam.com/api/common/v1"
+	v1_0 "go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -457,7 +457,7 @@ var (
 )
 
 func request_BoardService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client BoardServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -490,7 +490,7 @@ func request_BoardService_DoCommand_0(ctx context.Context, marshaler runtime.Mar
 }
 
 func local_request_BoardService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server BoardServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -892,7 +892,7 @@ var (
 )
 
 func request_BoardService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, client BoardServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -925,7 +925,7 @@ func request_BoardService_GetGeometries_0(ctx context.Context, marshaler runtime
 }
 
 func local_request_BoardService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, server BoardServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/component/camera/v1/camera.pb.gw.go
+++ b/component/camera/v1/camera.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	"go.viam.com/api/common/v1"
+	v1_0 "go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -351,7 +351,7 @@ var (
 )
 
 func request_CameraService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client CameraServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -384,7 +384,7 @@ func request_CameraService_DoCommand_0(ctx context.Context, marshaler runtime.Ma
 }
 
 func local_request_CameraService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server CameraServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -421,7 +421,7 @@ var (
 )
 
 func request_CameraService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, client CameraServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -454,7 +454,7 @@ func request_CameraService_GetGeometries_0(ctx context.Context, marshaler runtim
 }
 
 func local_request_CameraService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, server CameraServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/component/gantry/v1/gantry.pb.gw.go
+++ b/component/gantry/v1/gantry.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	v1_0 "go.viam.com/api/common/v1"
+	"go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -439,7 +439,7 @@ var (
 )
 
 func request_GantryService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client GantryServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -472,7 +472,7 @@ func request_GantryService_DoCommand_0(ctx context.Context, marshaler runtime.Ma
 }
 
 func local_request_GantryService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server GantryServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -509,7 +509,7 @@ var (
 )
 
 func request_GantryService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, client GantryServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.GetGeometriesRequest
+	var protoReq v1.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -542,7 +542,7 @@ func request_GantryService_GetGeometries_0(ctx context.Context, marshaler runtim
 }
 
 func local_request_GantryService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, server GantryServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.GetGeometriesRequest
+	var protoReq v1.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/component/gripper/v1/gripper.pb.gw.go
+++ b/component/gripper/v1/gripper.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	"go.viam.com/api/common/v1"
+	v1_0 "go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -299,7 +299,7 @@ var (
 )
 
 func request_GripperService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client GripperServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -332,7 +332,7 @@ func request_GripperService_DoCommand_0(ctx context.Context, marshaler runtime.M
 }
 
 func local_request_GripperService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server GripperServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -369,7 +369,7 @@ var (
 )
 
 func request_GripperService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, client GripperServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -402,7 +402,7 @@ func request_GripperService_GetGeometries_0(ctx context.Context, marshaler runti
 }
 
 func local_request_GripperService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, server GripperServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/component/inputcontroller/v1/input_controller.pb.gw.go
+++ b/component/inputcontroller/v1/input_controller.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	"go.viam.com/api/common/v1"
+	v1_0 "go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -292,7 +292,7 @@ var (
 )
 
 func request_InputControllerService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client InputControllerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -325,7 +325,7 @@ func request_InputControllerService_DoCommand_0(ctx context.Context, marshaler r
 }
 
 func local_request_InputControllerService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server InputControllerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -362,7 +362,7 @@ var (
 )
 
 func request_InputControllerService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, client InputControllerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -395,7 +395,7 @@ func request_InputControllerService_GetGeometries_0(ctx context.Context, marshal
 }
 
 func local_request_InputControllerService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, server InputControllerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.GetGeometriesRequest
+	var protoReq v1_0.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/component/posetracker/v1/pose_tracker.pb.gw.go
+++ b/component/posetracker/v1/pose_tracker.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	v1_0 "go.viam.com/api/common/v1"
+	"go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -107,7 +107,7 @@ var (
 )
 
 func request_PoseTrackerService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client PoseTrackerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -140,7 +140,7 @@ func request_PoseTrackerService_DoCommand_0(ctx context.Context, marshaler runti
 }
 
 func local_request_PoseTrackerService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server PoseTrackerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -177,7 +177,7 @@ var (
 )
 
 func request_PoseTrackerService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, client PoseTrackerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.GetGeometriesRequest
+	var protoReq v1.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -210,7 +210,7 @@ func request_PoseTrackerService_GetGeometries_0(ctx context.Context, marshaler r
 }
 
 func local_request_PoseTrackerService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, server PoseTrackerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.GetGeometriesRequest
+	var protoReq v1.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/component/servo/v1/servo.pb.gw.go
+++ b/component/servo/v1/servo.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	v1_0 "go.viam.com/api/common/v1"
+	"go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -299,7 +299,7 @@ var (
 )
 
 func request_ServoService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client ServoServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -332,7 +332,7 @@ func request_ServoService_DoCommand_0(ctx context.Context, marshaler runtime.Mar
 }
 
 func local_request_ServoService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server ServoServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -369,7 +369,7 @@ var (
 )
 
 func request_ServoService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, client ServoServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.GetGeometriesRequest
+	var protoReq v1.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -402,7 +402,7 @@ func request_ServoService_GetGeometries_0(ctx context.Context, marshaler runtime
 }
 
 func local_request_ServoService_GetGeometries_0(ctx context.Context, marshaler runtime.Marshaler, server ServoServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.GetGeometriesRequest
+	var protoReq v1.GetGeometriesRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.viam.com/api
 
-go 1.19
+go 1.21.13
 
 require (
 	github.com/bufbuild/buf v1.6.0

--- a/service/datamanager/v1/data_manager.pb.gw.go
+++ b/service/datamanager/v1/data_manager.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	"go.viam.com/api/common/v1"
+	v1_0 "go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -107,7 +107,7 @@ var (
 )
 
 func request_DataManagerService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client DataManagerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -140,7 +140,7 @@ func request_DataManagerService_DoCommand_0(ctx context.Context, marshaler runti
 }
 
 func local_request_DataManagerService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server DataManagerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/service/generic/v1/generic.pb.gw.go
+++ b/service/generic/v1/generic.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	"go.viam.com/api/common/v1"
+	v1_0 "go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -37,7 +37,7 @@ var (
 )
 
 func request_GenericService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client GenericServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -70,7 +70,7 @@ func request_GenericService_DoCommand_0(ctx context.Context, marshaler runtime.M
 }
 
 func local_request_GenericService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server GenericServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/service/sensors/v1/sensors.pb.gw.go
+++ b/service/sensors/v1/sensors.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	v1_0 "go.viam.com/api/common/v1"
+	"go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -177,7 +177,7 @@ var (
 )
 
 func request_SensorsService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client SensorsServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -210,7 +210,7 @@ func request_SensorsService_DoCommand_0(ctx context.Context, marshaler runtime.M
 }
 
 func local_request_SensorsService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server SensorsServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_0.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/service/shell/v1/shell.pb.gw.go
+++ b/service/shell/v1/shell.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	"go.viam.com/api/common/v1"
+	v1_0 "go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -166,7 +166,7 @@ var (
 )
 
 func request_ShellService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client ShellServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -199,7 +199,7 @@ func request_ShellService_DoCommand_0(ctx context.Context, marshaler runtime.Mar
 }
 
 func local_request_ShellService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server ShellServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/service/slam/v1/slam.pb.gw.go
+++ b/service/slam/v1/slam.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	"go.viam.com/api/common/v1"
+	v1_0 "go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -220,7 +220,7 @@ var (
 )
 
 func request_SLAMService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client SLAMServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -253,7 +253,7 @@ func request_SLAMService_DoCommand_0(ctx context.Context, marshaler runtime.Mars
 }
 
 func local_request_SLAMService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server SLAMServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1.DoCommandRequest
+	var protoReq v1_0.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (

--- a/service/vision/v1/vision.pb.gw.go
+++ b/service/vision/v1/vision.pb.gw.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	v1_1 "go.viam.com/api/common/v1"
+	"go.viam.com/api/common/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -527,7 +527,7 @@ var (
 )
 
 func request_VisionService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, client VisionServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_1.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (
@@ -560,7 +560,7 @@ func request_VisionService_DoCommand_0(ctx context.Context, marshaler runtime.Ma
 }
 
 func local_request_VisionService_DoCommand_0(ctx context.Context, marshaler runtime.Marshaler, server VisionServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq v1_1.DoCommandRequest
+	var protoReq v1.DoCommandRequest
 	var metadata runtime.ServerMetadata
 
 	var (


### PR DESCRIPTION
## What changed
- bump min go version in go.mod to 1.21.13
## Why
netip vuln https://pkg.go.dev/vuln/GO-2024-2887