### PR TITLE
APP-6580: Adding fragment + org cost structure

### DIFF
--- a/proto/viam/app/v1/billing.proto
+++ b/proto/viam/app/v1/billing.proto
@@ -28,16 +28,6 @@ message InvoiceSummary {
   google.protobuf.Timestamp paid_date = 6;
 }
 
-message BillableResourceEvent {
-  string id = 1;
-  string type = 2;
-  double usage_quantity = 3;
-  string usage_quantity_unit = 4;
-  string usage_cost = 5;
-  google.protobuf.Timestamp occurred_at = 6;
-  string user_name = 7;
-}
-
 enum PaymentMethodType {
   PAYMENT_METHOD_TYPE_UNSPECIFIED = 0;
   PAYMENT_METHOD_TYPE_CARD = 1;

--- a/proto/viam/app/v1/billing.proto
+++ b/proto/viam/app/v1/billing.proto
@@ -38,16 +38,6 @@ message BillableResourceEvent {
   string user_name = 7;
 }
 
-message Invoice {
-  string id = 1;
-  google.protobuf.Timestamp invoice_date = 2;
-  double invoice_amount = 3;
-  string status = 4;
-  google.protobuf.Timestamp due_date = 5;
-  repeated BillableResourceEvent items = 6;
-  string emailed_to = 7;
-}
-
 enum PaymentMethodType {
   PAYMENT_METHOD_TYPE_UNSPECIFIED = 0;
   PAYMENT_METHOD_TYPE_CARD = 1;
@@ -74,9 +64,21 @@ enum UsageCostType {
   USAGE_COST_TYPE_PER_MACHINE = 8;
 }
 
+enum SourceType {
+  SOURCE_TYPE_UNSPECIFIED = 0;
+  SOURCE_TYPE_ORG = 1;
+  SOURCE_TYPE_FRAGMENT = 2;
+}
+
 message UsageCost {
   UsageCostType resource_type = 1;
   double cost = 2;
+}
+
+message ResourceUsageCostsBySource {
+  SourceType source_type = 1;
+  ResourceUsageCosts resource_usage_costs = 2;
+  string tier_name = 3;
 }
 
 message ResourceUsageCosts {
@@ -86,18 +88,11 @@ message ResourceUsageCosts {
   double total_without_discount = 4;
 }
 
-message FragmentUsageCosts {
-  string fragment_id = 1;
-  ResourceUsageCosts resource_usage_costs = 2;
-}
-
 message GetCurrentMonthUsageResponse {
   google.protobuf.Timestamp start_date = 1;
   google.protobuf.Timestamp end_date = 2;
-
-  ResourceUsageCosts org_usage = 14;
-  repeated FragmentUsageCosts fragment_usage_costs = 15;
-  double subtotal = 16;
+  repeated ResourceUsageCostsBySource resource_usage_costs_by_source = 3;
+  double subtotal = 4;
 }
 
 message GetOrgBillingInformationRequest {

--- a/proto/viam/app/v1/billing.proto
+++ b/proto/viam/app/v1/billing.proto
@@ -63,29 +63,30 @@ message GetCurrentMonthUsageRequest {
 }
 
 enum UsageCostType {
-  CLOUD_STORAGE = 1; 
-  DATA_UPLOAD = 2; 
-  DATA_EGRESS = 3;
-  REMOTE_CONTROL = 4; 
-  STANDARD_COMPUTE = 5; 
-  BINARY_DATA_CLOUD_STORAGE = 6; 
-  OTHER_CLOUD_STORAGE = 7;
-  PER_MACHINE = 8;
+  USAGE_COST_TYPE_UNSPECIFIED = 0;
+  USAGE_COST_TYPE_DATA_UPLOAD = 1;
+  USAGE_COST_TYPE_DATA_EGRESS = 2;
+  USAGE_COST_TYPE_REMOTE_CONTROL = 3;
+  USAGE_COST_TYPE_STANDARD_COMPUTE = 4;
+  USAGE_COST_TYPE_CLOUD_STORAGE = 5;
+  USAGE_COST_TYPE_BINARY_DATA_CLOUD_STORAGE = 6;
+  USAGE_COST_TYPE_OTHER_CLOUD_STORAGE = 7;
+  USAGE_COST_TYPE_PER_MACHINE = 8;
 }
 
 message UsageCost {
-  UsageCostType resource_type = 1; 
+  UsageCostType resource_type = 1;
   double cost = 2;
 }
 
 message GroupedCosts {
   repeated UsageCost usage_costs = 1;
-  double subtotal = 2; 
+  double subtotal = 2;
   double discount = 3;
 }
 
 message FragmentCosts {
-  string fragmentID = 1; 
+  string fragment_id = 1;
   GroupedCosts breakdown = 2;
 }
 
@@ -93,7 +94,7 @@ message GetCurrentMonthUsageResponse {
   google.protobuf.Timestamp start_date = 1;
   google.protobuf.Timestamp end_date = 2;
 
-  // This will be deprecated soon as it no longer 
+  // This will be deprecated soon as it no longer
   // reflects fragment cost structure
   double cloud_storage_usage_cost = 3;
   double data_upload_usage_cost = 4;
@@ -106,10 +107,10 @@ message GetCurrentMonthUsageResponse {
   double per_machine_usage_cost = 11;
   double binary_data_cloud_storage_usage_cost = 12;
   double other_cloud_storage_usage_cost = 13;
- 
-  repeated GroupedCosts OrgBreakdown = 14;
-  repeated FragmentCosts FragmentsBreakdown = 15;
-  double subtotal = 16; // total for all org + fragment costs 
+
+  repeated GroupedCosts org_breakdown = 14;
+  repeated FragmentCosts fragment_breakdown = 15;
+  double subtotal = 16; // total for all org + fragment costs
 }
 
 message GetOrgBillingInformationRequest {

--- a/proto/viam/app/v1/billing.proto
+++ b/proto/viam/app/v1/billing.proto
@@ -62,9 +62,39 @@ message GetCurrentMonthUsageRequest {
   string org_id = 1;
 }
 
+enum UsageCostType {
+  CLOUD_STORAGE = 1; 
+  DATA_UPLOAD = 2; 
+  DATA_EGRESS = 3;
+  REMOTE_CONTROL = 4; 
+  STANDARD_COMPUTE = 5; 
+  BINARY_DATA_CLOUD_STORAGE = 6; 
+  OTHER_CLOUD_STORAGE = 7;
+  PER_MACHINE = 8;
+}
+
+message UsageCost {
+  UsageCostType resource_type = 1; 
+  double cost = 2;
+}
+
+message GroupedCosts {
+  repeated UsageCost usage_costs = 1;
+  double subtotal = 2; 
+  double discount = 3;
+}
+
+message FragmentCosts {
+  string fragmentID = 1; 
+  GroupedCosts breakdown = 2;
+}
+
 message GetCurrentMonthUsageResponse {
   google.protobuf.Timestamp start_date = 1;
   google.protobuf.Timestamp end_date = 2;
+
+  // This will be deprecated soon as it no longer 
+  // reflects fragment cost structure
   double cloud_storage_usage_cost = 3;
   double data_upload_usage_cost = 4;
   double data_egres_usage_cost = 5;
@@ -76,6 +106,10 @@ message GetCurrentMonthUsageResponse {
   double per_machine_usage_cost = 11;
   double binary_data_cloud_storage_usage_cost = 12;
   double other_cloud_storage_usage_cost = 13;
+ 
+  repeated GroupedCosts OrgBreakdown = 14;
+  repeated FragmentCosts FragmentsBreakdown = 15;
+  double subtotal = 16; // total for all org + fragment costs 
 }
 
 message GetOrgBillingInformationRequest {

--- a/proto/viam/app/v1/billing.proto
+++ b/proto/viam/app/v1/billing.proto
@@ -81,8 +81,21 @@ message ResourceUsageCosts {
 message GetCurrentMonthUsageResponse {
   google.protobuf.Timestamp start_date = 1;
   google.protobuf.Timestamp end_date = 2;
-  repeated ResourceUsageCostsBySource resource_usage_costs_by_source = 3;
-  double subtotal = 4;
+  repeated ResourceUsageCostsBySource resource_usage_costs_by_source = 14;
+  double subtotal = 15;
+
+  // all fields below are deprecated
+  double cloud_storage_usage_cost = 3 [deprecated = true];
+  double data_upload_usage_cost = 4 [deprecated = true];
+  double data_egres_usage_cost = 5 [deprecated = true];
+  double remote_control_usage_cost = 6 [deprecated = true];
+  double standard_compute_usage_cost = 7 [deprecated = true];
+  double discount_amount = 8 [deprecated = true];
+  double total_usage_with_discount = 9 [deprecated = true];
+  double total_usage_without_discount = 10 [deprecated = true];
+  double per_machine_usage_cost = 11 [deprecated = true];
+  double binary_data_cloud_storage_usage_cost = 12 [deprecated = true];
+  double other_cloud_storage_usage_cost = 13 [deprecated = true];
 }
 
 message GetOrgBillingInformationRequest {

--- a/proto/viam/app/v1/billing.proto
+++ b/proto/viam/app/v1/billing.proto
@@ -79,38 +79,25 @@ message UsageCost {
   double cost = 2;
 }
 
-message GroupedCosts {
+message ResourceUsageCosts {
   repeated UsageCost usage_costs = 1;
-  double subtotal = 2;
-  double discount = 3;
+  double discount = 2;
+  double total_with_discount = 3;
+  double total_without_discount = 4;
 }
 
-message FragmentCosts {
+message FragmentUsageCosts {
   string fragment_id = 1;
-  GroupedCosts breakdown = 2;
+  ResourceUsageCosts resource_usage_costs = 2;
 }
 
 message GetCurrentMonthUsageResponse {
   google.protobuf.Timestamp start_date = 1;
   google.protobuf.Timestamp end_date = 2;
 
-  // This will be deprecated soon as it no longer
-  // reflects fragment cost structure
-  double cloud_storage_usage_cost = 3;
-  double data_upload_usage_cost = 4;
-  double data_egres_usage_cost = 5;
-  double remote_control_usage_cost = 6;
-  double standard_compute_usage_cost = 7;
-  double discount_amount = 8;
-  double total_usage_with_discount = 9;
-  double total_usage_without_discount = 10;
-  double per_machine_usage_cost = 11;
-  double binary_data_cloud_storage_usage_cost = 12;
-  double other_cloud_storage_usage_cost = 13;
-
-  repeated GroupedCosts org_breakdown = 14;
-  repeated FragmentCosts fragment_breakdown = 15;
-  double subtotal = 16; // total for all org + fragment costs
+  ResourceUsageCosts org_usage = 14;
+  repeated FragmentUsageCosts fragment_usage_costs = 15;
+  double subtotal = 16;
 }
 
 message GetOrgBillingInformationRequest {


### PR DESCRIPTION
Our current `GetCurrentMonthUsage` response is built only for Org related costs. We now want to show fragment charges + credits via this API as well as org level costs (which we do because we use it in [APP](https://github.com/viamrobotics/app/pull/6451)) then we need to update how we return this information. 

This change allows us to group by orgs and fragments and show how the discounts are applied to each of these separate charge types. 

**As as drive by** here I removed the types `Invoice` and `BillableResourceEvent` as they are not used anywhere and is confusing to people.