### PR TITLE
APP-6392: add errors field to ListMachineFragments response

### DIFF
--- a/proto/viam/app/v1/app.proto
+++ b/proto/viam/app/v1/app.proto
@@ -745,6 +745,20 @@ enum FragmentVisibility {
   FRAGMENT_VISIBILITY_PUBLIC_UNLISTED = 3;
 }
 
+message FragmentError {
+  FragmentErrorType error_type = 1;
+  string fragment_id = 2;
+  string detail = 3;
+}
+
+enum FragmentErrorType {
+  FRAGMENT_ERROR_TYPE_UNSPECIFIED = 0;
+  FRAGMENT_ERROR_TYPE_NO_ACCESS = 1;
+  FRAGMENT_ERROR_TYPE_NESTING_LIMIT_EXCEEDED = 2;
+  FRAGMENT_ERROR_TYPE_CHILD_ID_INVALID = 3;
+  FRAGMENT_ERROR_TYPE_DUPLICATE_NAMES = 4;
+}
+
 message ListFragmentsRequest {
   string organization_id = 1;
   bool show_public = 2;
@@ -818,6 +832,7 @@ message ListMachineFragmentsRequest {
 
 message ListMachineFragmentsResponse {
   repeated Fragment fragments = 1;
+  repeated FragmentError errors = 2;
 }
 
 message ListRobotsResponse {


### PR DESCRIPTION
## Overview

This PR adds the necessary proto fields to report nested fragments errors from the `ListMachineFragments` endpoint

## Change log

- Define `FragmentError` message
- Add `repeated FragmentError` to `ListMachineFragmentsResponse`

Note: APP-6392 spec'd adding errors to the `Fragment` object. After getting into the code, I'm not sure that's the best move. Will probably keep this PR in draft for a while so I can spin up APP-5422 and see how it feels from the top-down rather than try to get this shape right from the bottom up

## Review requests

Check back later!