### PR TITLE
Allow metadata in Tunnel messages

### DIFF
--- a/proto/viam/robot/v1/robot.proto
+++ b/proto/viam/robot/v1/robot.proto
@@ -127,10 +127,12 @@ service RobotService {
 message TunnelRequest {
   uint32 destination_port = 1;
   bytes data = 2;
+  map<string, google.protobuf.Any>  metadata = 3;
 }
 
 message TunnelResponse {
   bytes data = 1;
+  map<string, google.protobuf.Any>  metadata = 2;
 }
 
 message ListTunnelsRequest {}


### PR DESCRIPTION
will allow for sending metadata over the wire (things like sent time or debug flags), which will be super helpful in improving/debugging performance

but also open to adding the necessary fields directly (e.g. session_id, timestamp, debug). just thought doing it as a map is a bit easier and allows us to iterate quickly.

can't use grpc metadata for timestamp, since that is sent only once per streaming call.