### PR TITLE
Allow conditionally skipping buf-breaking check w/ label

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
   pull_request_target:
     branches: [ 'main' ]
-    types: [opened, synchronize, reopened, unlabeled]
+    types: [opened, synchronize, reopened, unlabeled, labeled]
 
 jobs:
   test:
@@ -34,6 +34,7 @@ jobs:
     # Run all Lint runs
     - uses: bufbuild/buf-lint-action@v1
     # Run breaking change detection against the `main` branch
-    - uses: bufbuild/buf-breaking-action@v1
+    - uses: bufbuild/buf-breaking-action@c57b3d842a5c3f3b454756ef65305a50a587c5ba
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'allow breaking') }}
       with:
         against: 'https://github.com/viamrobotics/api.git#branch=main'


### PR DESCRIPTION
There's an active PR in #749 that is trying to rename several fields to `<name>_depricated` while reusing the original name for a new field number. This will maintain proto message compatibility but be a breaking change in the generated go code, where `Get<Name>` will now return a different type. This is intended. It is currently not possible to merge that PR because `buf-breaking-action` detects the renamed fields and fails a required check. We could get someone with admin access to bypass the branch protection rules, but if this is a form of breaking change we think is valid then I think there should be a more direct way for engineers to opt a PR out of the check. This PR implements that via a label that will skip the `buf-breaking-action` while still running the rest of the check, which at time of writing is just the buf linter.