### PR TITLE
Allow unsafe PR checkouts (forks)

### DIFF
--- a/.github/workflows/compile_protos.yml
+++ b/.github/workflows/compile_protos.yml
@@ -44,6 +44,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           # note: check out fork because we will need it when we push below
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          # Fork PRs only reach pull_request_target runs behind the 'safe to test' label (see pr-labeler.yml).
+          allow-unsafe-pr-checkout: true
 
       - name: Set environment variables for previous commit
         run: |

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -20,6 +20,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        # Fork PRs only reach pull_request_target runs behind the 'safe to test' label (see pr-labeler.yml).
+        allow-unsafe-pr-checkout: true
     - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac
       with:
         install: false


### PR DESCRIPTION
Same as https://github.com/viamrobotics/goutils/pull/587 for api: adds `allow-unsafe-pr-checkout: true` to the two `pull_request_target` checkout steps (pullrequest.yml and compile_protos.yml). Fork PRs only reach these jobs behind the 'safe to test' label (see pr-labeler.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)