### PR TITLE
Re-check sender org membership in label-gated pull_request_target jobs

### DIFF
--- a/.github/workflows/compile_protos.yml
+++ b/.github/workflows/compile_protos.yml
@@ -30,10 +30,37 @@ jobs:
         GH_REPO: ${{ github.repository }}
       run: gh pr edit ${{ github.event.pull_request.number }} --remove-label protos-compiled
 
+  authorize:
+    # The label gate below alone is not safe: the label check reads the event payload,
+    # which still lists 'safe to test' on a push made after a maintainer applied it
+    # (pr-labeler.yml strips it too late for that run). Re-checking the sender's org
+    # membership at run time closes the gap: a push from a non-member never runs.
+    name: Check Sender Membership
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    outputs:
+      is-member: ${{ steps.membership.outputs.result }}
+    steps:
+      - name: Check org membership
+        id: membership
+        # actions/github-script@v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            const sender = context.payload.sender.login;
+            try {
+              // checkMembershipForUser returns 204 for members and throws a 404 for non-members.
+              const resp = await github.rest.orgs.checkMembershipForUser({org: "viamrobotics", username: sender});
+              return resp.status === 204;
+            } catch (err) {
+              core.info(`${sender} is not a viamrobotics org member: ${err}`);
+              return false;
+            }
+
   compile-protos:
     # run after unlabel so that ordering of remove-label, add-label is consistent
-    needs: unlabel
-    if: contains(github.event.pull_request.labels.*.name, 'safe to test') && contains(github.event.pull_request.labels.*.name, 'ready-for-protos')
+    needs: [unlabel, authorize]
+    if: needs.authorize.outputs.is-member == 'true' && contains(github.event.pull_request.labels.*.name, 'safe to test') && contains(github.event.pull_request.labels.*.name, 'ready-for-protos')
     runs-on: ubuntu-latest
     env:
       CI_COMMIT_MESSAGE_PREFIX: Built new protos from
@@ -44,7 +71,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           # note: check out fork because we will need it when we push below
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          # Fork PRs only reach pull_request_target runs behind the 'safe to test' label (see pr-labeler.yml).
+          # Fork PRs only run behind the 'safe to test' label (pr-labeler.yml) plus the
+          # authorize job's run-time sender check above.
           allow-unsafe-pr-checkout: true
 
       - name: Set environment variables for previous commit

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -11,16 +11,45 @@ on:
     types: [opened, synchronize, reopened, unlabeled, labeled]
 
 jobs:
+  authorize:
+    # The 'safe to test' label alone is not a safe gate: the label check below reads the
+    # event payload, which still lists the label on a push made after a maintainer applied
+    # it (pr-labeler.yml strips it too late for that run). Re-checking the sender's org
+    # membership at run time closes the gap: a push from a non-member never runs.
+    name: Check Sender Membership
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    outputs:
+      is-member: ${{ steps.membership.outputs.result }}
+    steps:
+    - name: Check org membership
+      id: membership
+      # actions/github-script@v9.0.0
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+      with:
+        script: |
+          const sender = context.payload.sender.login;
+          try {
+            // checkMembershipForUser returns 204 for members and throws a 404 for non-members.
+            const resp = await github.rest.orgs.checkMembershipForUser({org: "viamrobotics", username: sender});
+            return resp.status === 204;
+          } catch (err) {
+            core.info(`${sender} is not a viamrobotics org member: ${err}`);
+            return false;
+          }
+
   test:
     name: Test For Lint and Breaking Changes
-    if: contains(github.event.pull_request.labels.*.name, 'safe to test')
+    needs: authorize
+    if: needs.authorize.outputs.is-member == 'true' && contains(github.event.pull_request.labels.*.name, 'safe to test')
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
-        # Fork PRs only reach pull_request_target runs behind the 'safe to test' label (see pr-labeler.yml).
+        # Fork PRs only run behind the 'safe to test' label (pr-labeler.yml) plus the
+        # authorize job's run-time sender check above.
         allow-unsafe-pr-checkout: true
     - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac
       with:


### PR DESCRIPTION
The 'safe to test' gate in pullrequest.yml and compile_protos.yml reads labels from the event payload. A push made after a maintainer labels the PR therefore runs once with the stale label: the `synchronize` event snapshot still lists it, and pr-labeler.yml strips it too late for that run. An attacker could get one commit reviewed, labeled, then push unreviewed code that runs under `pull_request_target`.

Each gated job now also requires an `authorize` job that checks the event sender's viamrobotics org membership at run time (the same API call pr-labeler already makes). A push from a non-member never runs, no matter what the payload says. Fork PRs from outside contributors still run when a maintainer applies the label: that `labeled` event has the maintainer as sender and carries the head SHA they reviewed.

Alternative considered: rdk and goutils trigger their trusted workflows on `labeled` events only, with a labeler that removes and re-adds the label per push using a PAT (`PR_TOKEN`). This repo's labeler uses `GITHUB_TOKEN`, whose label events do not trigger other workflows, so that pattern here would silently stop per-push CI for org members' fork PRs unless the repo gains a PAT. The run-time membership check needs no new secret and keeps current CI behavior for members.

One behavior note: org members whose membership is private may resolve as non-members with `GITHUB_TOKEN`; those members already fail pr-labeler's identical check today (they get the 'must be labeled' comment), so this adds no new friction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)